### PR TITLE
enable debug tooling

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -684,8 +684,9 @@ require('lazy').setup({
         'autopep8', -- Used to format python code
         'flake8', -- Used to format python code
         'eslint_d', -- Used to lint js code
+        'jsonlint', -- Used to lint json files
         'markdownlint', -- Used to lint markdown code
-        'prettier', -- Used to format typescript code
+        'prettierd', -- Used to format typescript code
         'rubocop', -- Used to format ruby code
       })
 
@@ -714,7 +715,7 @@ require('lazy').setup({
     ---@type conform.setupOpts
     opts = {
       notify_on_error = false,
-      format_on_save = function(bufnr)
+      format_after_save = function(bufnr)
         -- Disable "format_on_save lsp_fallback" for languages that don't
         -- have a well standardized coding style. You can add additional
         -- languages here or re-enable it for the disabled ones.
@@ -723,7 +724,7 @@ require('lazy').setup({
           return nil
         else
           return {
-            timeout_ms = 2000,
+            timeout_ms = 500,
             lsp_format = 'fallback',
           }
         end
@@ -734,9 +735,10 @@ require('lazy').setup({
         -- python = { "isort", "black" },
         --
         -- You can use 'stop_after_first' to run the first available formatter from the list
-        javascript = { 'prettierd', 'prettier', stop_after_first = true },
-        typescript = { 'prettierd', 'prettier', stop_after_first = true },
-        typescriptreact = { 'prettierd', 'prettier', stop_after_first = true },
+        json = { 'prettierd', 'prettier', stop_after_first = false },
+        javascript = { 'eslint_d', 'prettierd', stop_after_first = false },
+        typescript = { 'eslint_d', 'prettierd', stop_after_first = false },
+        typescriptreact = { 'eslint_d', 'prettierd', stop_after_first = false },
       },
     },
   },
@@ -981,7 +983,7 @@ require('lazy').setup({
   --  Here are some example plugins that I've included in the Kickstart repository.
   --  Uncomment any of the lines below to enable them (you will need to restart nvim).
   --
-  -- require 'kickstart.plugins.debug',
+  require 'kickstart.plugins.debug',
   -- require 'kickstart.plugins.indent_line',
   require 'kickstart.plugins.lint',
   -- require 'kickstart.plugins.autopairs',

--- a/lua/kickstart/plugins/debug.lua
+++ b/lua/kickstart/plugins/debug.lua
@@ -8,6 +8,25 @@
 
 ---@module 'lazy'
 ---@type LazySpec
+local CURRENT_TEST_CONFIG = 'Run current test'
+local CURRENT_TEST_FILE_CONFIG = 'Run current test file'
+
+-- Helper function to run a DAP config by name, resolving any functions in the config
+local function run_config(config_name)
+  local dap = require 'dap'
+  local ft = vim.bo.filetype
+  local target = vim.tbl_filter(function(c) return c.name == config_name end, dap.configurations[ft] or {})[1]
+  if not target then
+    vim.notify('Config "' .. config_name .. '" not found for ' .. ft, vim.log.levels.WARN)
+    return
+  end
+  local resolved = {}
+  for k, v in pairs(target) do
+    resolved[k] = type(v) == 'function' and v() or v
+  end
+  dap.run(resolved)
+end
+
 return {
   -- NOTE: Yes, you can install new plugins here!
   'mfussenegger/nvim-dap',
@@ -36,6 +55,11 @@ return {
     { '<leader>B', function() require('dap').set_breakpoint(vim.fn.input 'Breakpoint condition: ') end, desc = 'Debug: Set Breakpoint' },
     -- Toggle to see last session result. Without this, you can't see session output in case of unhandled exception.
     { '<F7>', function() require('dapui').toggle() end, desc = 'Debug: See last session result.' },
+    { '<leader>dr', function() require('dap').repl.open() end, desc = 'Debug: Open REPL' },
+    { '<leader>dl', function() require('dap').run_last() end, desc = 'Debug: Run Last' },
+    { '<leader>de', function() require('dapui').eval() end, desc = 'Debug: Eval expression', mode = { 'n', 'v' } },
+    { '<leader>df', function() run_config(CURRENT_TEST_FILE_CONFIG) end, desc = 'Debug: ' .. CURRENT_TEST_FILE_CONFIG },
+    { '<leader>dt', function() run_config(CURRENT_TEST_CONFIG) end, desc = 'Debug: ' .. CURRENT_TEST_CONFIG },
   },
   config = function()
     local dap = require 'dap'
@@ -55,6 +79,7 @@ return {
       ensure_installed = {
         -- Update this to ensure that you have the debuggers for the langs you want
         'delve',
+        'js',
       },
     }
 
@@ -83,16 +108,16 @@ return {
     }
 
     -- Change breakpoint icons
-    -- vim.api.nvim_set_hl(0, 'DapBreak', { fg = '#e51400' })
-    -- vim.api.nvim_set_hl(0, 'DapStop', { fg = '#ffcc00' })
-    -- local breakpoint_icons = vim.g.have_nerd_font
-    --     and { Breakpoint = '', BreakpointCondition = '', BreakpointRejected = '', LogPoint = '', Stopped = '' }
-    --   or { Breakpoint = '●', BreakpointCondition = '⊜', BreakpointRejected = '⊘', LogPoint = '◆', Stopped = '⭔' }
-    -- for type, icon in pairs(breakpoint_icons) do
-    --   local tp = 'Dap' .. type
-    --   local hl = (type == 'Stopped') and 'DapStop' or 'DapBreak'
-    --   vim.fn.sign_define(tp, { text = icon, texthl = hl, numhl = hl })
-    -- end
+    vim.api.nvim_set_hl(0, 'DapBreak', { fg = '#e51400' })
+    vim.api.nvim_set_hl(0, 'DapStop', { fg = '#ffcc00' })
+    local breakpoint_icons = vim.g.have_nerd_font
+        and { Breakpoint = '', BreakpointCondition = '', BreakpointRejected = '', LogPoint = '', Stopped = '' }
+      or { Breakpoint = '●', BreakpointCondition = '⊜', BreakpointRejected = '⊘', LogPoint = '◆', Stopped = '⭔' }
+    for type, icon in pairs(breakpoint_icons) do
+      local tp = 'Dap' .. type
+      local hl = (type == 'Stopped') and 'DapStop' or 'DapBreak'
+      vim.fn.sign_define(tp, { text = icon, texthl = hl, numhl = hl })
+    end
 
     dap.listeners.after.event_initialized['dapui_config'] = dapui.open
     dap.listeners.before.event_terminated['dapui_config'] = dapui.close
@@ -106,5 +131,83 @@ return {
         detached = vim.fn.has 'win32' == 0,
       },
     }
+
+    dap.adapters = {
+      ['pwa-node'] = {
+        type = 'server',
+        host = '::1',
+        port = '${port}',
+        executable = {
+          command = 'js-debug-adapter',
+          args = {
+            '${port}',
+          },
+        },
+      },
+    }
+
+    for _, language in ipairs { 'typescript', 'javascript' } do
+      require('dap').configurations[language] = {
+        {
+          type = 'pwa-node',
+          request = 'launch',
+          name = CURRENT_TEST_FILE_CONFIG,
+          runtimeExecutable = 'node',
+          runtimeArgs = function()
+            return {
+              '${workspaceFolder}/node_modules/jest/bin/jest.js',
+              '--runInBand',
+              '--no-coverage',
+              '--testTimeout=60000',
+              vim.fn.expand '%:.',
+            }
+          end,
+          rootPath = '${workspaceFolder}',
+          cwd = '${workspaceFolder}',
+          console = 'integratedTerminal',
+          internalConsoleOptions = 'neverOpen',
+          resolveSourceMapLocations = { '${workspaceFolder}/**', '!**/node_modules/**' },
+          skipFiles = { '<node_internals>/**', '**/node_modules/**' },
+          sourceMaps = true,
+        },
+        {
+          type = 'pwa-node',
+          request = 'launch',
+          name = CURRENT_TEST_CONFIG,
+          runtimeExecutable = 'node',
+          runtimeArgs = function()
+            -- Walk up from cursor to find nearest it/test/describe name
+            local function get_test_name()
+              local linenr = vim.fn.line '.'
+              for i = linenr, 1, -1 do
+                local line = vim.fn.getline(i)
+                local name = line:match '%f[%w_]it%s*%(%s*[\'"](.+)[\'"]'
+                  or line:match '%f[%w_]test%s*%(%s*[\'"](.+)[\'"]'
+                  or line:match '%f[%w_]describe%s*%(%s*[\'"](.+)[\'"]'
+                if name then return name end
+              end
+              return ''
+            end
+            local name = get_test_name()
+            local args = {
+              './node_modules/jest/bin/jest.js',
+              '--runInBand',
+              '--no-coverage',
+              '--testTimeout=60000',
+              vim.fn.expand '%:.',
+            }
+            if name ~= '' then vim.list_extend(args, { '--testNamePattern', name }) end
+            return args
+          end,
+          rootPath = '${workspaceFolder}',
+          cwd = '${workspaceFolder}',
+          console = 'integratedTerminal',
+          internalConsoleOptions = 'neverOpen',
+          sourceMaps = true,
+          skipFiles = { '<node_internals>/**', '**/node_modules/**' },
+          resolveSourceMapLocations = { '${workspaceFolder}/**', '!**/node_modules/**' },
+        },
+      }
+    end
   end,
 }

--- a/lua/kickstart/plugins/lint.lua
+++ b/lua/kickstart/plugins/lint.lua
@@ -8,7 +8,12 @@ return {
   config = function()
     local lint = require 'lint'
     lint.linters_by_ft = {
+      -- javascript = { 'eslint_d' }, -- for .js
       markdown = { 'markdownlint' },
+      json = { 'jsonlint' },
+      -- ruby = { 'rubocop' },
+      -- typescript = { 'eslint_d' },
+      -- typescriptreact = { 'eslint_d' }, -- for .tsx
     }
 
     -- To allow other plugins to add linters to require('lint').linters_by_ft,


### PR DESCRIPTION
### Summary

### Changes 
- ensuring prettierd and jsonlint installed 
- running eslint_d and prettierd after save and reducing timeout to 500 ms
- enabling linting json files
- enabling debug tooling
  - Adding shortcuts to "debug current test", debug current file and execute latest executed debug test command regardless of where are you positioned.