### PR TITLE
support both vitest and jest

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -701,6 +701,12 @@ do
       mason = false,
       cmd = { vim.fn.expand '~/.rbenv/shims/ruby-lsp' },
     },
+    -- enable type checking and other features for Ruby with Sorbet
+    sorbet = {
+      mason = false,
+      cmd = { 'bundle', 'exec', 'srb', 'tc', '--lsp' },
+      filetypes = { 'ruby' },
+    },
     rust_analyzer = {},
     pylsp = {
       settings = {
@@ -981,6 +987,7 @@ do
     'ruby',
     'rust',
     'typescript',
+    'tsx',
     'yaml',
   }
   require('nvim-treesitter').install(parsers)

--- a/lua/kickstart/plugins/debug.lua
+++ b/lua/kickstart/plugins/debug.lua
@@ -122,7 +122,7 @@ require('dap-go').setup {
 dap.adapters = {
   ['pwa-node'] = {
     type = 'server',
-    host = '127.0.0.1',
+    host = '::1',
     port = '${port}',
     executable = {
       command = 'js-debug-adapter',
@@ -133,6 +133,23 @@ dap.adapters = {
   },
 }
 
+local function is_vitest_configured(workspaceFolder)
+  return vim.fn.filereadable(workspaceFolder .. '/vitest.config.ts') == 1 or vim.fn.filereadable(workspaceFolder .. '/vitest.config.js') == 1
+end
+
+local function get_test_runner_args(workspaceFolder)
+  if is_vitest_configured(workspaceFolder) then return { workspaceFolder .. '/node_modules/.bin/vitest', 'run' } end
+  return { workspaceFolder .. '/node_modules/jest/bin/jest.js', '--no-coverage' }
+end
+
+local function get_runtime_args()
+  local args = get_test_runner_args(vim.fn.getcwd())
+  return vim.list_extend(args, {
+    '--testTimeout=60000',
+    vim.fn.expand '%:.',
+  })
+end
+
 for _, language in ipairs { 'typescript', 'javascript' } do
   require('dap').configurations[language] = {
     {
@@ -140,16 +157,7 @@ for _, language in ipairs { 'typescript', 'javascript' } do
       request = 'launch',
       name = CURRENT_TEST_FILE_CONFIG,
       runtimeExecutable = 'node',
-      runtimeArgs = function()
-        return {
-          -- '${workspaceFolder}/node_modules/jest/bin/jest.js',
-          '${workspaceFolder}/node_modules/.bin/vitest',
-          'run',
-          -- '--no-coverage',
-          '--testTimeout=60000',
-          vim.fn.expand '%:.',
-        }
-      end,
+      runtimeArgs = function() return get_runtime_args() end,
       rootPath = '${workspaceFolder}',
       cwd = '${workspaceFolder}',
       console = 'integratedTerminal',
@@ -176,16 +184,10 @@ for _, language in ipairs { 'typescript', 'javascript' } do
           end
           return ''
         end
+
+        local args = get_runtime_args()
+
         local name = get_test_name()
-        local args = {
-          -- './node_modules/jest/bin/jest.js',
-          '${workspaceFolder}/node_modules/.bin/vitest',
-          'run',
-          -- '--runInBand',
-          '--no-coverage',
-          '--testTimeout=60000',
-          vim.fn.expand '%:.',
-        }
         if name ~= '' then vim.list_extend(args, { '--testNamePattern', name }) end
         return args
       end,

--- a/lua/kickstart/plugins/lint.lua
+++ b/lua/kickstart/plugins/lint.lua
@@ -4,12 +4,12 @@ vim.pack.add { 'https://github.com/mfussenegger/nvim-lint' }
 
 local lint = require 'lint'
 lint.linters_by_ft = {
-  -- javascript = { 'eslint_d' }, -- for .js
+  javascript = { 'eslint_d' }, -- for .js
   json = { 'jsonlint' },
   markdown = { 'markdownlint' }, -- Make sure to install `markdownlint` via mason / npm
   -- ruby = { 'rubocop' },
-  -- typescript = { 'eslint_d' },
-  -- typescriptreact = { 'eslint_d' }, -- for .tsx
+  typescript = { 'eslint_d' },
+  typescriptreact = { 'eslint_d' }, -- for .tsx
 }
 
 -- To allow other plugins to add linters to require('lint').linters_by_ft,
@@ -47,7 +47,7 @@ lint.linters_by_ft = {
 -- Create autocommand which carries out the actual linting
 -- on the specified events.
 local lint_augroup = vim.api.nvim_create_augroup('lint', { clear = true })
-vim.api.nvim_create_autocmd({ 'BufEnter', 'BufWritePost', 'InsertLeave' }, {
+vim.api.nvim_create_autocmd({ 'BufEnter', 'BufWritePost', 'InsertLeave', 'TextChanged' }, {
   group = lint_augroup,
   callback = function()
     -- Only run the linter in buffers that you can modify in order to


### PR DESCRIPTION
# Changes

- support vitest and jest when debugging typescript repos
- adds sorbet to enable type checking ruby repos
- adds `tsx` parser to highlight typescriptreact files in the same way as typescript files.
- configures eslint_d as linter for typescript, javascript and typescriptreact files
- runs configured linter on `TextChanged` events. Meaning, file editions in normal mode.